### PR TITLE
Fixes bug in ShearProduction kernel

### DIFF
--- a/examples/constant_stratification_constant_fluxes.jl
+++ b/examples/constant_stratification_constant_fluxes.jl
@@ -200,7 +200,6 @@ data_directory = joinpath(@__DIR__, "..", "data", prefix) # save data in /data/p
 
 slice_interval = 15minute
 
-#=
 # Copy this file into the directory with data
 mkpath(data_directory)
 cp(@__FILE__, joinpath(data_directory, basename(@__FILE__)), force=true)
@@ -260,7 +259,6 @@ simulation.output_writers[:averaged_statistics] = JLD2OutputWriter(model, statis
 LESbrary.Utils.print_banner(simulation)
 
 run!(simulation)
-=#
 
 # # Load and plot turbulence statistics
 

--- a/src/TurbulenceStatistics/shear_production.jl
+++ b/src/TurbulenceStatistics/shear_production.jl
@@ -55,7 +55,7 @@ end
 
     @inbounds shear_production[i, j, k] = - (
         ℑxᶜᵃᵃ(i, j, k, grid, ψ′, u, U) * ℑzᵃᵃᶜ(i, j, k, grid, w∂zΨ, w, U) +
-        ℑyᵃᶜᵃ(i, j, k, grid, ψ′, v, U) * ℑzᵃᵃᶜ(i, j, k, grid, w∂zΨ, w, V) )
+        ℑyᵃᶜᵃ(i, j, k, grid, ψ′, v, V) * ℑzᵃᵃᶜ(i, j, k, grid, w∂zΨ, w, V) )
 end
 
 Adapt.adapt_structure(to, sp::ShearProduction) = Adapt.adapt(to, sp.data)


### PR DESCRIPTION
Fixes a bug observed by @qingli411 on #30 

We should come up with some simple analytical tests cases that we can run in order to sleep well at night. The dissipation term is a bit of a bear, but this shear production term is slightly easier. Something like `u = 1 + cos(x)`, etc?

@qingli411 let me know if this looks right.

Resolves #30 