### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To add `LESbrary.jl` to your julia environment, type
 ```julia
 julia> using Pkg
 
-julia> Pkg.add("https://github.com/CliMA/LESbrary.jl.git")
+julia> Pkg.add(url="https://github.com/CliMA/LESbrary.jl.git")
 ```
 
 at the REPL.


### PR DESCRIPTION
Using that syntax throws me this error:

```
ERROR: `https://github.com/CliMA/LESbrary.jl.git` is not a valid package name
The argument appears to be a URL or path, perhaps you meant `Pkg.add(url="...")` or `Pkg.add(path="...")`.
```

I'm assuming there was a change in a recent Julia version. The updated syntax appears to work (I'm using Julia version 1.5.2 by the way).