### PR TITLE
Utility function for diagnosing buoyancy flux for convection simulations from the buoyancy content of the column

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -670,6 +670,12 @@ git-tree-sha1 = "1be8800271c86f572d334fef6e3b8364eaece7d9"
 uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
 version = "1.6.2"
 
+[[QuadGK]]
+deps = ["DataStructures", "LinearAlgebra"]
+git-tree-sha1 = "12fbe86da16df6679be7521dfb39fbc861e1dc7b"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.4.1"
+
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"

--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ Oceanostics = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -4,6 +4,7 @@ export save_global!, print_banner, prefix_tuple_names, select_device!
 export SimulationProgressMessenger
 export fit_cubic
 export InterpolatedProfile, InterpolatedProfileTimeSeries, ∂z, ∂t
+export diagnose_buoyancy_flux
 
 using Printf
 
@@ -64,5 +65,6 @@ end
 include("progress_messenger.jl")
 include("fit_cubic.jl")
 include("interpolated_profiles.jl")
+include("diagnose_buoyancy_flux.jl")
 
 end # module

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -1,15 +1,9 @@
 module Utils
 
-export
-    save_global!,
-    print_banner,
-    prefix_tuple_names,
-    select_device!,
-
-    # progress_messenger.jl
-    SimulationProgressMessenger,
-
-    fit_cubic
+export save_global!, print_banner, prefix_tuple_names, select_device!
+export SimulationProgressMessenger
+export fit_cubic
+export InterpolatedProfile, InterpolatedProfileTimeSeries, ∂z, ∂t
 
 using Printf
 
@@ -69,5 +63,6 @@ end
 
 include("progress_messenger.jl")
 include("fit_cubic.jl")
+include("interpolated_profiles.jl")
 
 end # module

--- a/src/Utils/diagnose_buoyancy_flux.jl
+++ b/src/Utils/diagnose_buoyancy_flux.jl
@@ -4,16 +4,15 @@ using QuadGK
     diagnose_buoyancy_flux(b, z, time_period, depth)
 
 Returns the buoyancy flux (m²/s³) required to extract all the buoyancy from a 1D buoyancy profile `b(z)`
-down to some z-coordinate `depth` (< 0) over a `time_period` (s) by integrating the buoyancy profile and
-converting the integrated buoyancy content to an equivalent buoyancy flux:
+down to some z-coordinate `depth` (< 0) over a `time_period` τ (s) by integrating the buoyancy profile
+and converting the integrated buoyancy content to an equivalent buoyancy flux:
 
-          ⌠ z_surface
-    Qb =  |           [b(z) - b(depth)] dz
-          ⌡ depth
+          1  ⌠ z_surface
+    Qb = --- |           [b(z) - b(depth)] dz
+          τ  ⌡ depth
 """
 function diagnose_buoyancy_flux(b, z, time_period, depth)
 
-    Δτ = time_period
     Δz = z[2] - z[1]
     z_surface = last(z)
     @assert first(z) < depth < z_surface
@@ -24,5 +23,5 @@ function diagnose_buoyancy_flux(b, z, time_period, depth)
     integrand(z) = ℑb(z) - b₀
     B, err = quadgk(integrand, depth, z_surface)
 
-    return B / Δτ
+    return B / time_period
 end

--- a/src/Utils/diagnose_buoyancy_flux.jl
+++ b/src/Utils/diagnose_buoyancy_flux.jl
@@ -5,20 +5,24 @@ using QuadGK
 
 Returns the buoyancy flux (m²/s³) required to extract all the buoyancy from a 1D buoyancy profile `b(z)`
 down to some z-coordinate `depth` (< 0) over a `time_period` (s) by integrating the buoyancy profile and
-converting the integrated buoyancy content to an equivalent buoyancy flux.
+converting the integrated buoyancy content to an equivalent buoyancy flux:
+
+          ⌠ z_surface
+    Qb =  |           [b(z) - b(depth)] dz
+          ⌡ depth
 """
 function diagnose_buoyancy_flux(b, z, time_period, depth)
 
     Δτ = time_period
     Δz = z[2] - z[1]
-    @assert first(z) < depth < last(z)
+    z_surface = last(z)
+    @assert first(z) < depth < z_surface
 
-    ℑb = InterpolatedProfile(b, z, Δz, last(z))
-    b₀ = first(b)
+    ℑb = InterpolatedProfile(b, z, Δz, z_surface)
+    b₀ = ℑb(depth)
 
     integrand(z) = ℑb(z) - b₀
-    B, err = quadgk(integrand, depth, last(z))
-    @show err
+    B, err = quadgk(integrand, depth, z_surface)
 
     return B / Δτ
 end

--- a/src/Utils/diagnose_buoyancy_flux.jl
+++ b/src/Utils/diagnose_buoyancy_flux.jl
@@ -1,0 +1,24 @@
+using QuadGK
+
+"""
+    diagnose_buoyancy_flux(b, z, time_period, depth)
+
+Returns the buoyancy flux (m²/s³) required to extract all the buoyancy from a 1D buoyancy profile `b(z)`
+down to some z-coordinate `depth` (< 0) over a `time_period` (s) by integrating the buoyancy profile and
+converting the integrated buoyancy content to an equivalent buoyancy flux.
+"""
+function diagnose_buoyancy_flux(b, z, time_period, depth)
+
+    Δτ = time_period
+    Δz = z[2] - z[1]
+    @assert first(z) < depth < last(z)
+
+    ℑb = InterpolatedProfile(b, z, Δz, last(z))
+    b₀ = first(b)
+
+    integrand(z) = ℑb(z) - b₀
+    B, err = quadgk(integrand, depth, last(z))
+    @show err
+
+    return B / Δτ
+end

--- a/src/Utils/fit_cubic.jl
+++ b/src/Utils/fit_cubic.jl
@@ -22,4 +22,3 @@ function fit_cubic(p1, p2, s1, s2)
     results = nlsolve(f!, zeros(4))
     return results.zero
 end
-

--- a/src/Utils/interpolated_profiles.jl
+++ b/src/Utils/interpolated_profiles.jl
@@ -1,0 +1,126 @@
+import Adapt
+
+@inline fractional_index(x, xs, Δx) = @inbounds (x - xs[1]) / Δx
+
+# Linear Lagrange polynomials
+@inline ϕ₀(ξ) = 1 - ξ
+@inline ϕ₁(ξ) = ξ
+
+#####
+##### Linear interpolation for regularly spaced profiles e.g. T(z).
+#####
+
+struct InterpolatedProfile{D, Z, Δ, T}
+     data :: D
+        z :: Z
+       Δz :: Δ
+    z_max :: T
+end
+
+@inline function _interpolate(profile::InterpolatedProfile, zᵢ)
+    k = 1 + fractional_index(zᵢ, profile.z, profile.Δz)
+    ξ, k = mod(k, 1), Base.unsafe_trunc(Int, k)
+
+    # Ensure we don't go out of bounds.
+    if zᵢ >= profile.z_max
+        return @inbounds profile.data[k]
+    else
+        return @inbounds ϕ₀(ξ) * profile.data[k] + ϕ₁(ξ) * profile.data[k+1]
+    end
+end
+
+@inline (profile::InterpolatedProfile)(z) = _interpolate(profile, z)
+
+@inline function ∂z(profile::InterpolatedProfile, zᵢ)
+    k = 1 + fractional_index(zᵢ, profile.z, profile.Δz)
+    k = Base.unsafe_trunc(Int, k)
+    zᵢ >= profile.z_max && (k = k - 1) # Ensure we don't go out of bounds.
+    return @inbounds (profile.data[k+1] - profile.data[k]) / profile.Δz
+end
+
+Adapt.adapt_structure(to, profile::InterpolatedProfile) =
+    InterpolatedProfile(Adapt.adapt(to, profile.data),
+                        Adapt.adapt(to, profile.z),
+                        Adapt.adapt(to, profile.Δz),
+                        Adapt.adapt(to, profile.z_max))
+
+#####
+##### Linear interpolated for regularly spaced profile time series, e.g. T(z, t).
+#####
+
+struct InterpolatedProfileTimeSeries{D, Z, T, ΔZ, ΔT, FT}
+     data :: D
+        z :: Z
+        t :: T
+       Δz :: ΔZ
+       Δt :: ΔT
+    z_max :: FT
+    t_max :: FT
+end
+
+@inline function _interpolate(profile::InterpolatedProfileTimeSeries, zᵢ, tᵢ)
+    k = 1 + fractional_index(zᵢ, profile.z, profile.Δz)
+    n = 1 + fractional_index(tᵢ, profile.t, profile.Δt)
+
+    ξ, k = mod(k, 1), Base.unsafe_trunc(Int, k)
+    η, n = mod(n, 1), Base.unsafe_trunc(Int, n)
+
+    # Ensure we don't go out of bounds.
+    if zᵢ >= profile.z_max && tᵢ >= profile.t_max
+        return @inbounds profile.data[k, n]
+    elseif zᵢ >= profile.z_max
+        return @inbounds ϕ₀(η) * profile.data[k, n] + ϕ₁(η) * profile.data[k, n+1]
+    elseif tᵢ >= profile.t_max
+        return @inbounds ϕ₀(ξ) * profile.data[k, n] + ϕ₁(ξ) * profile.data[k+1, n]
+    else
+        return @inbounds (  ϕ₀(ξ) * ϕ₀(η) * profile.data[k,   n  ]
+                          + ϕ₀(ξ) * ϕ₁(η) * profile.data[k,   n+1]
+                          + ϕ₁(ξ) * ϕ₀(η) * profile.data[k+1, n  ]
+                          + ϕ₁(ξ) * ϕ₁(η) * profile.data[k+1, n+1])
+    end
+end
+
+@inline (profile::InterpolatedProfileTimeSeries)(z, t) = _interpolate(profile, z, t)
+
+@inline function ∂z(profile::InterpolatedProfileTimeSeries, zᵢ, tᵢ)
+    k = 1 + fractional_index(zᵢ, profile.z, profile.Δz)
+    n = 1 + fractional_index(tᵢ, profile.t, profile.Δt)
+
+    ξ, k = mod(k, 1), Base.unsafe_trunc(Int, k)
+    η, n = mod(n, 1), Base.unsafe_trunc(Int, n)
+
+    # Ensure we don't go out of bounds.
+    zᵢ >= profile.z_max && (k = k - 1)
+    tᵢ >= profile.t_max && (n = n - 1)
+
+    dataᵏ   = @inbounds ϕ₀(η) * profile.data[k,   n] + ϕ₁(η) * profile.data[k,   n+1]
+    dataᵏ⁺¹ = @inbounds ϕ₀(η) * profile.data[k+1, n] + ϕ₁(η) * profile.data[k+1, n+1]
+
+    return (dataᵏ⁺¹ - dataᵏ) / profile.Δz
+end
+
+@inline function ∂t(profile::InterpolatedProfileTimeSeries, zᵢ, tᵢ)
+    k = 1 + fractional_index(zᵢ, profile.z, profile.Δz)
+    n = 1 + fractional_index(tᵢ, profile.t, profile.Δt)
+
+    ξ, k = mod(k, 1), Base.unsafe_trunc(Int, k)
+    η, n = mod(n, 1), Base.unsafe_trunc(Int, n)
+
+    # Ensure we don't go out of bounds.
+    zᵢ >= profile.z_max && (k = k - 1)
+    tᵢ >= profile.t_max && (n = n - 1)
+
+    dataⁿ   = @inbounds ϕ₀(ξ) * profile.data[k,   n] + ϕ₁(ξ) * profile.data[k+1,   n]
+    dataⁿ⁺¹ = @inbounds ϕ₀(ξ) * profile.data[k, n+1] + ϕ₁(ξ) * profile.data[k+1, n+1]
+
+    return (dataⁿ⁺¹ - dataⁿ) / profile.Δt
+end
+
+Adapt.adapt_structure(to, profile::InterpolatedProfileTimeSeries) =
+    InterpolatedProfileTimeSeries(Adapt.adapt(to, profile.data),
+                                  Adapt.adapt(to, profile.z),
+                                  Adapt.adapt(to, profile.t),
+                                  Adapt.adapt(to, profile.Δz),
+                                  Adapt.adapt(to, profile.Δt),
+                                  Adapt.adapt(to, profile.z_max),
+                                  Adapt.adapt(to, profile.t_max))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,8 @@ Logging.global_logger(OceananigansLogger())
 architectures = [CPU()]
 
 @testset "LESbrary" begin
-    include("test_utils.jl")
+    include("test_fit_cubic.jl")
+    include("test_interpolated_profiles.jl")
     include("test_turbulence_statistics.jl")
     include("test_examples.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ Logging.global_logger(OceananigansLogger())
 architectures = [CPU()]
 
 @testset "LESbrary" begin
+    include("test_utils.jl")
     include("test_turbulence_statistics.jl")
     include("test_examples.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ architectures = [CPU()]
 @testset "LESbrary" begin
     include("test_fit_cubic.jl")
     include("test_interpolated_profiles.jl")
+    include("test_diagnose_buoyancy_flux.jl")
     include("test_turbulence_statistics.jl")
     include("test_examples.jl")
 end

--- a/test/test_diagnose_buoyancy_flux.jl
+++ b/test/test_diagnose_buoyancy_flux.jl
@@ -1,0 +1,32 @@
+using Statistics
+using LESbrary.Utils
+
+# This test replicates the setup from Souza et al. (2020) and compares
+# the answer with Eq. (4). We expect agreement to machine precision.
+#
+# Souza et al. (2020). Uncertainty quantification of ocean parameterizations: Application to
+# the K‐Profile‐Parameterization for penetrative convection. Journal of Advances in Modeling
+# Earth Systems, 12, e2020MS002108. DOI: https://doi.org/10.1029/2020MS002108
+
+@testset "diagnose_buoyancy_flux" begin
+    α  = 2e-4
+    g  = 9.81
+    N² = 1e-5
+    b(z) = 20*α*g + N²*z
+
+    zs = range(-100, 0, length=64)
+    bs = [b(z) for z in zs]
+
+    days = 86400
+    Δτ = 8days
+
+    # We want the mixed layer to reach half the domain height.
+    depth = mean(zs)
+
+    Qb = diagnose_buoyancy_flux(bs, zs, Δτ, depth)
+
+    h = abs(depth)
+    Qb_empirical = h^2  * N² / (2Δτ)
+
+    @test Qb ≈ Qb_empirical
+end

--- a/test/test_fit_cubic.jl
+++ b/test/test_fit_cubic.jl
@@ -1,8 +1,5 @@
 using LESbrary.Utils
 
-using Pkg
-Pkg.develop(path=joinpath(@__DIR__, "..", "realistic"))
-
 @testset "fit_cubic" begin
     c = fit_cubic((0, 0), (1, 1), 0, 0)
 

--- a/test/test_interpolated_profiles.jl
+++ b/test/test_interpolated_profiles.jl
@@ -1,6 +1,7 @@
 using Test
 using Statistics
 using LESbrary.Utils
+using LESbrary.Utils: ∂z, ∂t
 
 @testset "InterpolatedProfile" begin
 
@@ -11,7 +12,7 @@ using LESbrary.Utils
     N = length(zs)
     data = randn(N)
 
-    prof = InterpolatedProfile(data, zs, Δz)
+    prof = InterpolatedProfile(data, zs, Δz, zs[end])
 
     @test prof(0) == prof.data[1]
     @test prof(5) == prof.data[2]
@@ -27,7 +28,7 @@ using LESbrary.Utils
     f(z) = z^2
     data = f.(zs)
 
-    prof = InterpolatedProfile(data, zs, Δz)
+    prof = InterpolatedProfile(data, zs, Δz, zs[end])
 
     @test ∂z(prof, 2) ≈ (f(5) - f(0)) / Δz
     @test ∂z(prof, 7.4) ≈ (f(10) - f(5)) / Δz
@@ -50,7 +51,7 @@ end
     Nt = length(ts)
     data = randn(Nz, Nt)
 
-    prof = InterpolatedProfileTimeSeries(data, zs, ts, Δz, Δt)
+    prof = InterpolatedProfileTimeSeries(data, zs, ts, Δz, Δt, zs[end], ts[end])
 
     @test prof(0, 0) == prof.data[1, 1]
     @test prof(5, 0) == prof.data[2, 1]
@@ -71,7 +72,7 @@ end
     f(z, t) = 3z^2 + 0.1t^2
     data = f.(zs, ts')
 
-    prof = InterpolatedProfileTimeSeries(data, zs, ts, Δz, Δt)
+    prof = InterpolatedProfileTimeSeries(data, zs, ts, Δz, Δt, zs[end], ts[end])
 
     @test ∂z(prof, 3, 0) ≈ (f(5, 0) - f(0, 0)) / Δz
     @test ∂z(prof, 7.5, 10) ≈ (f(10, 10) - f(5, 10)) / Δz

--- a/test/test_interpolated_profiles.jl
+++ b/test/test_interpolated_profiles.jl
@@ -1,0 +1,83 @@
+using Test
+using Statistics
+using LESbrary.Utils
+
+@testset "InterpolatedProfile" begin
+
+    # interpolation
+
+    zs = 0:5:50
+    Δz = zs.step
+    N = length(zs)
+    data = randn(N)
+
+    prof = InterpolatedProfile(data, zs, Δz)
+
+    @test prof(0) == prof.data[1]
+    @test prof(5) == prof.data[2]
+
+    @test prof(12.5) ≈ (prof.data[3] + prof.data[4]) / 2
+
+    # derivatives
+
+    zs = 0:5:50
+    Δz = zs.step
+    N = length(zs)
+
+    f(z) = z^2
+    data = f.(zs)
+
+    prof = InterpolatedProfile(data, zs, Δz)
+
+    @test ∂z(prof, 2) ≈ (f(5) - f(0)) / Δz
+    @test ∂z(prof, 7.4) ≈ (f(10) - f(5)) / Δz
+    @test ∂z(prof, 11.8) ≈ (f(15) - f(10)) / Δz
+
+    @test ∂z(prof, 2) == ∂z(prof, 4)
+    @test ∂z(prof, 7.4) == ∂z(prof, 9.99)
+    @test ∂z(prof, 11.8) == ∂z(prof, 10.01)
+end
+
+@testset "InterpolatedProfileTimeSeries" begin
+
+    # interpolation
+
+    zs = 0:5:50
+    ts = 0:60:600
+    Δz = zs.step
+    Δt = ts.step
+    Nz = length(zs)
+    Nt = length(ts)
+    data = randn(Nz, Nt)
+
+    prof = InterpolatedProfileTimeSeries(data, zs, ts, Δz, Δt)
+
+    @test prof(0, 0) == prof.data[1, 1]
+    @test prof(5, 0) == prof.data[2, 1]
+    @test prof(0, 60) == prof.data[1, 2]
+    @test prof(5, 60) == prof.data[2, 2]
+
+    @test prof(27.5, 330) ≈ mean(prof.data[6:7, 6:7])
+
+    # derivatives
+
+    zs = 0:5:50
+    ts = 0:60:600
+    Δz = zs.step
+    Δt = ts.step
+    Nz = length(zs)
+    Nt = length(ts)
+
+    f(z, t) = 3z^2 + 0.1t^2
+    data = f.(zs, ts')
+
+    prof = InterpolatedProfileTimeSeries(data, zs, ts, Δz, Δt)
+
+    @test ∂z(prof, 3, 0) ≈ (f(5, 0) - f(0, 0)) / Δz
+    @test ∂z(prof, 7.5, 10) ≈ (f(10, 10) - f(5, 10)) / Δz
+    @test ∂z(prof, 10.01, 420.69) ≈ (f(15, 420.69) - f(10, 420.69)) / Δz
+
+    @test ∂t(prof, 0, 45) ≈ (f(0, 60) - f(0, 0)) / Δt
+    @test ∂t(prof, 6, 100) ≈ (f(6, 120) - f(6, 60)) / Δt
+    @test ∂t(prof, 22.2, 310) ≈ (f(22.2, 360) - f(22.2, 300)) / Δt
+end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,14 @@
+using LESbrary.Utils
+
+using Pkg
+Pkg.develop(path=joinpath(@__DIR__, "..", "realistic"))
+
+@testset "fit_cubic" begin
+    c = fit_cubic((0, 0), (1, 1), 0, 0)
+
+    # We should get back 3x^2 - 2x^3
+    @test c[1] ≈ 0 atol=1e-12
+    @test c[2] ≈ 0 atol=1e-12
+    @test c[3] ≈ 3
+    @test c[4] ≈ -2
+end


### PR DESCRIPTION
This PR adds a util `diagnose_buoyancy_flux` that returns the buoyancy flux (m²/s³) required to extract all the buoyancy from a 1D buoyancy profile `b(z)` down to some z-coordinate `depth` (< 0) over a time_period `τ` (seconds) by integrating the buoyancy profile and converting the integrated buoyancy content to an equivalent buoyancy flux:

```
          1  ⌠ z_surface
    Qb = --- |           [b(z) - b(depth)] dz
          τ  ⌡ depth
```

This should be useful for setting up simulations where you only want the mixed layer to deepen to some depth (e.g. H/2) over some amount of time (e.g. 8 days), especially when the buoyancy profile is not constant (e.g. piecewise linear or cubic).

Might be overkill for the simulation suite that @adelinehillier has set up, but I'm hoping to use it to set up simulations for training neural differential equations.

I also added a test to make sure it agrees with the "empirical law of convection" described in Souza et al. (2020), equation (4).

PS: This PR also moves `interpolated_profiles.jl` from RealisticLESbrary.jl into LESbrary.jl.