### PR TITLE
Tweak idealized experiments interface

### DIFF
--- a/idealized/run_lesbrary_simulations.jl
+++ b/idealized/run_lesbrary_simulations.jl
@@ -16,7 +16,8 @@ all_parameters = tuple(values(two_day_suite_parameters)...,
 
 for size in ((64, 64, 64), (128, 128, 128), (256, 256, 256))
     for parameters in all_parameters
-        run_three_layer_constant_fluxes_simulation(; architecture, size, parameters...)
+        simulation = three_layer_constant_fluxes_simulation(; architecture, size, parameters...)
+        run!(simulation)
     end
 end
     

--- a/src/IdealizedExperiments/three_layer_constant_fluxes.jl
+++ b/src/IdealizedExperiments/three_layer_constant_fluxes.jl
@@ -40,7 +40,7 @@ function execute(cmd::Cmd)
     return (stdout = out |> read |> String, stderr = err |> read |> String, code = process.exitcode)
 end
 
-function run_three_layer_constant_fluxes_simulation(;
+function three_layer_constant_fluxes_simulation(;
     name = "",
     size = (32, 32, 32),
     extent = (512meters, 512meters, 256meters),
@@ -418,9 +418,7 @@ function run_three_layer_constant_fluxes_simulation(;
         end
     end
 
-    run!(simulation)
-
-    return data_directory
+    return simultion
 end
 
 function squeeze(A)

--- a/src/IdealizedExperiments/three_layer_constant_fluxes.jl
+++ b/src/IdealizedExperiments/three_layer_constant_fluxes.jl
@@ -418,7 +418,7 @@ function three_layer_constant_fluxes_simulation(;
         end
     end
 
-    return simultion
+    return simulation
 end
 
 function squeeze(A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,4 +6,5 @@ include("runtests_preamble.jl")
     include("test_diagnose_buoyancy_flux.jl")
     include("test_turbulence_statistics.jl")
     include("test_examples.jl")
+    include("test_experiments.jl")
 end


### PR DESCRIPTION
This PR changes `run_three_layer_constant_fluxes_simulation` (which builds _and_ `run!` a simulation) to `three_layer_constant_fluxes_simulation`, which simply constructs the simulation.

This makes it possible to edit the `simulation` after building it and before calling `run!`, eg, changing callbacks, or maybe just calling `time_step!(simulation)` rather than `run!` for doing timings or debugging, etc.

cc @sandreza @navidcy important for you two if you implement constructors for the baroclinic adjustment experiment or eddying channel experiment.

@christophernhill this change is useful for squeezing metrics out of "three layer, constant fluxes" LES on a cloud instance or something.

It also tests this function on CI (we wrote the test, but forgot to add it to `runtests.jl`).